### PR TITLE
fix: [SRP-1148] fix itemscope microdata schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deepcrawl/web-auto-extractor",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Automatically extracts structured information from webpages",
   "main": "dist/index.js",
   "scripts": {

--- a/src/parsers/micro-rdfa-parser.js
+++ b/src/parsers/micro-rdfa-parser.js
@@ -15,17 +15,18 @@ function getPropValue(tagName, attribs, TYPE, PROP) {
 }
 
 const getAttrNames = (specName) => {
-  let TYPE, PROP;
+  let TYPE, PROP, REQU;
   if (specName.toLowerCase().startsWith("micro")) {
     TYPE = "itemtype";
     PROP = "itemprop";
+    REQU = "itemscope";
   } else if (specName.toLowerCase().startsWith("rdfa")) {
     TYPE = "typeof";
     PROP = "property";
   } else {
     throw new Error("Unsupported spec: use either micro or rdfa");
   }
-  return { TYPE, PROP };
+  return { TYPE, PROP, REQU };
 };
 
 const getType = (typeString) => {
@@ -41,13 +42,13 @@ const createHandler = function (specName) {
   let tags = [];
   let topLevelScope = {};
   let textForProp = null;
-  const { TYPE, PROP } = getAttrNames(specName);
+  const { TYPE, PROP, REQU } = getAttrNames(specName);
 
   const onopentag = function (tagName, attribs) {
     let currentScope = scopes[scopes.length - 1];
     let tag = false;
-
     if (attribs[TYPE]) {
+      if (REQU && !attribs.hasOwnProperty(REQU)) return
       if (attribs[PROP] && currentScope) {
         let newScope = {};
         currentScope[attribs[PROP]] = currentScope[attribs[PROP]] || [];

--- a/test/resources/expectedResult.json
+++ b/test/resources/expectedResult.json
@@ -1,29 +1,26 @@
 {
   "metatags": {
-    "priceCurrency": [
-      "USD",
-      "USD"
-    ],
-    "datePublished": [
-      "2009-05-08"
-    ],
-    "prepTime": [
-      "PT15M"
-    ],
-    "cookTime": [
-      "PT1H"
-    ],
-    "interactionType": [
-      "http://schema.org/CommentAction"
-    ],
-    "refresh": [
-       "30"
-    ],
-    "userInteractionCount": [
-      "140"
-    ]
+    "priceCurrency": ["USD", "USD"],
+    "datePublished": ["2009-05-08"],
+    "prepTime": ["PT15M"],
+    "cookTime": ["PT1H"],
+    "interactionType": ["http://schema.org/CommentAction"],
+    "refresh": ["30"],
+    "userInteractionCount": ["140"]
   },
   "microdata": {
+    "Offer": [
+      {
+        "@context": "http://schema.org/",
+        "@type": "Offer",
+        "availability": "https://schema.org/InStock",
+        "itemCondition": "https://schema.org/UsedCondition",
+        "price": "119.99",
+        "priceCurrency": "USD",
+        "priceValidUntil": "2020-11-20",
+        "url": "https://example.com/anvil"
+      }
+    ],
     "Product": [
       {
         "@context": "http://schema.org/",
@@ -74,11 +71,7 @@
           "calories": "240 calories",
           "fatContent": "9 grams fat"
         },
-        "recipeIngredient": [
-          "3 or 4 ripe bananas, smashed",
-          "1 egg",
-          "3/4 cup of sugar"
-        ],
+        "recipeIngredient": ["3 or 4 ripe bananas, smashed", "1 egg", "3/4 cup of sugar"],
         "recipeInstructions": "Preheat the oven to 350 degrees. Mix in the ingredients in a bowl. Add\n  the flour last. Pour the mixture into a loaf pan and bake for one hour.",
         "interactionStatistic": {
           "@context": "http://schema.org/",

--- a/test/resources/testPage.html
+++ b/test/resources/testPage.html
@@ -53,6 +53,17 @@
   }
 ]
 </script>
+<div itemtype="http://schema.org/IndividualProduct">
+  <span itemprop="name">Executive Anvil</span>
+  <div itemprop="offers" itemtype="http://schema.org/Offer" itemscope>
+    <link itemprop="url" href="https://example.com/anvil" />
+    <link itemprop="availability" href="https://schema.org/InStock" />
+    <span itemprop="priceCurrency">USD</span>
+    <link itemprop="itemCondition" href="https://schema.org/UsedCondition" />
+    <span itemprop="price">119.99</span>
+    <span itemprop="priceValidUntil">2020-11-20</span>
+  </div>
+</div>
 <div itemscope itemtype="http://schema.org/Product">
   <span itemprop="brand">ACME</span>
   <span itemprop="name">Executive Anvil</span>


### PR DESCRIPTION
Current parser ignores `itemscope` attribute and returns schema only if it has `itemtype`. Sccording to spec `itemscope` is used to create microdata elements in the first place.

- Add required attribute name for micro specName
- If Parsing attribute `itemtype`, ignore it if the tag does not have required attribute
- If the schemas are nested and the parent schema is missing `itemscope`, the child schema will be reported as top level. This behaviour is the same when tested in schema.org validator.

Ticket: https://lumarhq.atlassian.net/browse/SRP-1148