### PR TITLE
Remove itemtype from metatags

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deepcrawl/web-auto-extractor",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "Automatically extracts structured information from webpages",
   "main": "dist/index.js",
   "scripts": {

--- a/src/parsers/micro-rdfa-parser.js
+++ b/src/parsers/micro-rdfa-parser.js
@@ -1,7 +1,6 @@
 const htmlparser = require("htmlparser2");
 
 function getPropValue(tagName, attribs, TYPE, PROP) {
-  if (tagName === "meta" && attribs.itemtype) return null;
   if (attribs[TYPE]) {
     return null;
   } else if ((tagName === "a" || tagName === "link") && attribs.href) {

--- a/src/parsers/micro-rdfa-parser.js
+++ b/src/parsers/micro-rdfa-parser.js
@@ -46,7 +46,11 @@ const createHandler = function (specName) {
   const { TYPE, PROP, REQU } = getAttrNames(specName);
 
   const onopentag = function (tagName, attribs) {
-    if (tagName === "meta" && "itemtype" in attribs) {
+    if (
+      tagName === "meta" &&
+      "itemtype" in attribs &&
+      specName.toLowerCase().startsWith("micro")
+    ) {
       delete attribs.itemtype;
     }
 

--- a/src/parsers/micro-rdfa-parser.js
+++ b/src/parsers/micro-rdfa-parser.js
@@ -1,6 +1,7 @@
 const htmlparser = require("htmlparser2");
 
 function getPropValue(tagName, attribs, TYPE, PROP) {
+  if (tagName === "meta" && attribs.itemtype) return null;
   if (attribs[TYPE]) {
     return null;
   } else if ((tagName === "a" || tagName === "link") && attribs.href) {
@@ -45,10 +46,14 @@ const createHandler = function (specName) {
   const { TYPE, PROP, REQU } = getAttrNames(specName);
 
   const onopentag = function (tagName, attribs) {
+    if (tagName === "meta" && "itemtype" in attribs) {
+      delete attribs.itemtype;
+    }
+
     let currentScope = scopes[scopes.length - 1];
     let tag = false;
     if (attribs[TYPE]) {
-      if (REQU && !attribs.hasOwnProperty(REQU)) return
+      if (REQU && !attribs.hasOwnProperty(REQU)) return;
       if (attribs[PROP] && currentScope) {
         let newScope = {};
         currentScope[attribs[PROP]] = currentScope[attribs[PROP]] || [];
@@ -75,7 +80,6 @@ const createHandler = function (specName) {
           currentScope[attribs[PROP]] &&
           !Array.isArray(currentScope[attribs[PROP]])
         ) {
-          // PROP occurs for the second time, storing it as an array
           currentScope[attribs[PROP]] = [currentScope[attribs[PROP]]];
         }
 

--- a/test/resources/expectedResult.json
+++ b/test/resources/expectedResult.json
@@ -1,12 +1,30 @@
 {
   "metatags": {
-    "priceCurrency": ["USD", "USD"],
+    "priceCurrency": ["USD", "USD", "GBP"],
     "datePublished": ["2009-05-08"],
     "prepTime": ["PT15M"],
     "cookTime": ["PT1H"],
     "interactionType": ["http://schema.org/CommentAction"],
     "refresh": ["30"],
-    "userInteractionCount": ["140"]
+    "userInteractionCount": ["140"],
+    "price": ["159"],
+    "color": ["Brown"],
+    "sku": ["OEPJX150-C01"],
+    "itemCondition": [
+      "http://schema.org/NewCondition",
+      "https://schema.org/NewCondition"
+    ],
+    "name": ["Brown Leather Tassel Loafer"],
+    "availability": ["http://schema.org/InStock"],
+    "ratingValue": ["4.9"],
+    "reviewCount": ["8"],
+    "priceValidUntil": ["2025-04-24"],
+    "description": [
+      "A classic brown loafer with preppy charm, these shoes are superbly manufactured for a timeless investment. Constructed from premium leather with leather lining and leather soles, this classic design is made your comfort and durability. \n<br/>\n<br/>• Leather Upper\n<br/>• Leather Lining\n<br/>• Leather Sole \n<br/>• Rubber Heel \n<br/><br/> Made in Portugal"
+    ],
+    "image": [
+      "https://images.hawesandcurtis.com/tr:q-80/OE/OEPJX150-C01-166860-870px-1002px.jpg"
+    ]
   },
   "microdata": {
     "Offer": [
@@ -50,6 +68,34 @@
           "itemCondition": "http://schema.org/UsedCondition",
           "availability": "http://schema.org/InStock"
         }
+      },
+      {
+        "@context": "http://schema.org/",
+        "@type": "Product",
+        "color": "Brown",
+        "description": "A classic brown loafer with preppy charm, these shoes are superbly manufactured for a timeless investment. Constructed from premium leather with leather lining and leather soles, this classic design is made your comfort and durability. \n<br/>\n<br/>• Leather Upper\n<br/>• Leather Lining\n<br/>• Leather Sole \n<br/>• Rubber Heel \n<br/><br/> Made in Portugal",
+        "image": "https://images.hawesandcurtis.com/tr:q-80/OE/OEPJX150-C01-166860-870px-1002px.jpg",
+        "name": "Brown Leather Tassel Loafer",
+        "sku": "OEPJX150-C01",
+        "AggregateRating": {
+          "@context": "http://schema.org/",
+          "@type": "AggregateRating",
+          "ratingValue": "4.9",
+          "reviewCount": "8"
+        },
+        "offers": {
+          "@context": "http://schema.org/",
+          "@type": "Offer",
+          "availability": "http://schema.org/InStock",
+          "itemCondition": [
+            "http://schema.org/NewCondition",
+            "https://schema.org/NewCondition"
+          ],
+          "price": "159",
+          "priceCurrency": "GBP",
+          "priceValidUntil": "2025-04-24",
+          "url": "/brown-leather-tassel-loafer-oepjx150-c01"
+        }
       }
     ],
     "Recipe": [
@@ -86,6 +132,7 @@
       }
     ]
   },
+
   "rdfa": {
     "Product": [
       {

--- a/test/resources/testPage.html
+++ b/test/resources/testPage.html
@@ -251,4 +251,28 @@ the Executive Anvil is perfect for the business
     <link property="availability" content="http://schema.org/InStock" />In stock! Order now!
   </span>
   </span>
+
+  <section itemscope="" itemtype="http://schema.org/Product">
+	<meta itemprop="sku" content="OEPJX150-C01" /><meta itemprop="name" content="Brown Leather Tassel Loafer" /><meta itemprop="color" content="Brown" />
+	<meta
+		itemprop="description"
+		content="A classic brown loafer with preppy charm, these shoes are superbly manufactured for a timeless investment. Constructed from premium leather with leather lining and leather soles, this classic design is made your comfort and durability. 
+<br/>
+<br/>• Leather Upper
+<br/>• Leather Lining
+<br/>• Leather Sole 
+<br/>• Rubber Heel 
+<br/><br/> Made in Portugal"
+	/>
+	<meta itemprop="image" content="https://images.hawesandcurtis.com/tr:q-80/OE/OEPJX150-C01-166860-870px-1002px.jpg" />
+	<div itemprop="offers" itemscope="" itemtype="http://schema.org/Offer">
+		<link itemprop="url" href="/brown-leather-tassel-loafer-oepjx150-c01" /><meta itemprop="itemCondition" itemtype="http://schema.org/OfferItemCondition" content="http://schema.org/NewCondition" />
+		<meta itemprop="availability" content="http://schema.org/InStock" /><meta itemprop="price" content="159" /><meta itemprop="priceCurrency" content="GBP" /><meta itemprop="itemCondition" content="https://schema.org/NewCondition" />
+		<meta itemprop="priceValidUntil" content="2025-04-24" />
+	</div>
+	<div itemprop="AggregateRating" itemscope="" itemtype="http://schema.org/AggregateRating">
+		<meta itemprop="ratingValue" content="4.9" />
+		<meta itemprop="reviewCount" content="8" />
+	</div>
+</section>
 </div>


### PR DESCRIPTION
When encountering itemtype within a metatag, the parser would incorrectly assume the block is over early.